### PR TITLE
fixing moving the cursor back and forth well issue according to user key press

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ class OTPTextView extends Component {
   onKeyPress = (e, i) => {
     const val = this.state.otpText[i] || "";
 
-    if (e.nativeEvent.key === "Backspace" && i !== 0 && !(val.length - 1)) {
+    if (e.nativeEvent.key === "Backspace" && i !== 0 && !val.length) {
       this.inputs[i - 1].focus();
     }
   };


### PR DESCRIPTION
- The cursor didn't move accordingly when the back button is pressed
- Fixed that issue
- Now on the first back it clears the text on the current input and shifts the cursor to the previous text input on the next back button press