### PR TITLE
Fixed backspace bug and more..

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,9 +90,29 @@ class OTPTextView extends Component {
 
   onKeyPress = (e, i) => {
     const val = this.state.otpText[i] || "";
-
-    if (e.nativeEvent.key === "Backspace" && i !== 0 && val.length === 1) {
-      this.inputs[i - 1].focus();
+    const { handleTextChange, inputCellLength } = this.props;
+    const { otpText } = this.state;
+    if (e.nativeEvent.key === "Backspace" && i !== 0) {
+      if (val.length === 0) {
+        if (otpText[i - 1].length === inputCellLength) {
+          this.setState(
+            (prevState) => {
+              let { otpText } = prevState;
+              otpText[i - 1] = otpText[i - 1]
+                .split("")
+                .splice(0, otpText[i - 1].length - 1)
+                .join("");
+              return {
+                otpText,
+              };
+            },
+            () => {
+              handleTextChange(this.state.otpText.join(""));
+              this.inputs[i - 1].focus();
+            }
+          );
+        }
+      }
     }
   };
 


### PR DESCRIPTION
Added more Realistic Effect:
Cursor automatically deletes the last input if current focused input is empty. Previously, it was not allowed to move to previous block if the current cell if empty.

Here's a small preview of what it does now.
Tested with multiple inputs in one cell also.


https://user-images.githubusercontent.com/68629996/191536769-e36b3db4-30a3-458e-8be2-01f015f97943.mp4

