### PR TITLE
Add autoFocus prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The following props are applicable for the component along with **props supporte
 | containerStyle   | object | Yes      | {}           | style for overall container.                                                     |
 | textInputStyle   | object | Yes      | {}           | style for text input.                                                            |
 | testIDPrefix     | string | Yes      | 'otp*input*' | testID prefix, the result will be `otp_input_0` until inputCount                 |
+| autoFocus        | bool   | Yes      | false        | Input should automatically get focus when the components loads                   |
 
 #### Helper Functions
 

--- a/index.js
+++ b/index.js
@@ -223,7 +223,7 @@ class OTPTextView extends Component {
           key={i}
           autoCorrect={false}
           keyboardType={keyboardType}
-          autoFocus={i === 0}
+          autoFocus={this.props.autoFocus && i === 0}
           value={otpText[i] || ""}
           style={inputStyle}
           maxLength={this.props.inputCellLength}
@@ -260,6 +260,7 @@ OTPTextView.propTypes = {
   inputType: PropTypes.string,
   keyboardType: PropTypes.string,
   testIDPrefix: PropTypes.string,
+  autoFocus: PropTypes.bool
 };
 
 OTPTextView.defaultProps = {
@@ -273,6 +274,7 @@ OTPTextView.defaultProps = {
   handleTextChange: () => {},
   keyboardType: "numeric",
   testIDPrefix: "otp_input_",
+  autoFocus: false
 };
 
 export default OTPTextView;


### PR DESCRIPTION
Added a new prop - `autoFocus` - which allows you to specify which input element should receive focus when the component loads. This feature is especially useful for forms and search bars, where users need to input information quickly and efficiently. With autoFocus, you can improve accessibility and make it easier for users to interact with the application.

Secondly, have updated the Readme file to provide more comprehensive documentation 