### PR TITLE
doc: update syntax in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ render() {
 import React, { useRef } from 'react';
 
 const ParentComponent = () => {
-    const otpInput = useRef(null);
+    let otpInput = useRef(null);
 
     const clearText = () => {
         otpInput.current.clear();


### PR DESCRIPTION
Previously, the `const otpInput` variable was throwing an error due to its read-only status. In response, have updated the readme to provide more detailed instructions on how to handle this error and avoid similar issues in the future.

In addition, have changed the variable scope of `otpInput` by making this variable mutable in the example.