### PR TITLE
Extending props from TextInputProps to fix the type error when TextInput props is passed

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -7,6 +7,7 @@ import {
   KeyboardType,
   NativeSyntheticEvent,
   TextInputKeyPressEventData,
+  TextInputProps
 } from 'react-native';
 
 interface IState {
@@ -14,7 +15,7 @@ interface IState {
   otpText: string[];
 }
 
-interface IProps {
+interface IProps extends TextInputProps {
   defaultValue: string;
   inputCount: number;
   containerStyle: ViewStyle;


### PR DESCRIPTION
## Overview
If we pass any react native TextInput props, typescript complains. I have made a small change extending props from TextInputProps to accept any TextInput props. 